### PR TITLE
build(nix): update dependencies

### DIFF
--- a/.github/workflows/wit-deps.yml
+++ b/.github/workflows/wit-deps.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-linux:
+  build-bin:
     strategy:
       matrix:
         config:
@@ -20,11 +20,21 @@ jobs:
           test-oci: docker load < ./result
           # TODO: Run aarch64 binary within OCI
 
+        - target: aarch64-apple-darwin
+          install-path: /bin/wit-deps
+          test-bin: file ./result/bin/wit-deps
+          test-oci: docker load < ./result
+
         - target: armv7-unknown-linux-musleabihf
           install-path: /bin/wit-deps
           test-bin: nix shell --inputs-from . 'nixpkgs#qemu' -c qemu-arm ./result/bin/wit-deps --version
           test-oci: docker load < ./result
           # TODO: Run armv7 binary within OCI
+
+        - target: x86_64-apple-darwin
+          install-path: /bin/wit-deps
+          test-bin: file ./result/bin/wit-deps
+          test-oci: docker load < ./result
 
         - target: x86_64-pc-windows-gnu
           install-path: /bin/wit-deps.exe
@@ -56,38 +66,9 @@ jobs:
         package: wit-deps-${{ matrix.config.target }}-oci
     - run: ${{ matrix.config.test-oci }}
 
-  build-mac:
-    strategy:
-      matrix:
-        config:
-        - target: aarch64-apple-darwin
-          test: file ./result/bin/wit-deps
-          # TODO: Run aarch64 binary on host system and via OCI
-
-        - target: x86_64-apple-darwin
-          test: ./result/bin/wit-deps --version
-
-    name: wit-deps-${{ matrix.config.target }}
-    runs-on: macos-12
-    steps:
-    - uses: actions/checkout@v3
-    - uses: ./.github/actions/install-nix
-      with: 
-        cachixAuthToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-    - uses: ./.github/actions/build-nix
-      with:
-        package: wit-deps-${{ matrix.config.target }}
-        install-path: /bin/wit-deps
-    - run: ${{ matrix.config.test-bin }}
-    - uses: ./.github/actions/build-nix
-      with:
-        package: wit-deps-${{ matrix.config.target }}-oci
-    - run: ${{ matrix.platform.test-oci }}
-    # TODO: Test OCI on Mac
-
   build-lipo:
     name: wit-deps-universal-darwin
-    needs: build-mac
+    needs: build-bin
     runs-on: macos-12
     steps:
     - uses: actions/download-artifact@v3
@@ -96,6 +77,8 @@ jobs:
     - uses: actions/download-artifact@v3
       with:
         name: wit-deps-x86_64-apple-darwin
+    - run: chmod +x ./wit-deps-x86_64-apple-darwin
+    - run: ./wit-deps-x86_64-apple-darwin --version
     - run: lipo -create ./wit-deps-aarch64-apple-darwin ./wit-deps-x86_64-apple-darwin -output ./wit-deps-universal-darwin
     - run: chmod +x ./wit-deps-universal-darwin
     - run: ./wit-deps-universal-darwin --version
@@ -163,7 +146,7 @@ jobs:
 
   release:
     if: startsWith(github.ref, 'refs/tags/') && github.event_name == 'push'
-    needs: [ build-linux, build-lipo, build-doc, cargo ]
+    needs: [ build-bin, build-lipo, build-doc, cargo ]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "advisory-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1689698236,
-        "narHash": "sha256-Qz9JxGKeA3jwuj1CdK9ejMJ7VsJRdiZniF8lx4mft9s=",
+        "lastModified": 1692708302,
+        "narHash": "sha256-N7VVcezln+bo9qfySGOzBvkxm8YUhejwj1qDdx/nq+k=",
         "owner": "rustsec",
         "repo": "advisory-db",
-        "rev": "4aa517564d1d06f0e79784c8ad973a59d68aa9c8",
+        "rev": "214d69f12545eea7bb2e81dc8eddfe7a90697137",
         "type": "github"
       },
       "original": {
@@ -30,11 +30,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1688772518,
-        "narHash": "sha256-ol7gZxwvgLnxNSZwFTDJJ49xVY5teaSvF7lzlo3YQfM=",
+        "lastModified": 1692750383,
+        "narHash": "sha256-n5P5HOXuu23UB1h9PuayldnRRVQuXJLpoO+xqtMO3ws=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "8b08e96c9af8c6e3a2b69af5a7fa168750fcf88e",
+        "rev": "ef5d11e3c2e5b3924eb0309dba2e1fea2d9062ae",
         "type": "github"
       },
       "original": {
@@ -52,11 +52,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1689661376,
-        "narHash": "sha256-jK8m0FKjlI99iOOdor87yOjDHt8QsL/J/eMeCOzHJMM=",
+        "lastModified": 1692685213,
+        "narHash": "sha256-JOrXleSdEKuymCyxg7P4GTTATDhBdfeyWcd1qQQlIYw=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "cb4ed6a92123dd8e3befdf0fbed27c9ebb8e7176",
+        "rev": "ffa0a8815be591767f82d42c63d88bfa4026a967",
         "type": "github"
       },
       "original": {
@@ -96,6 +96,22 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "macos-sdk": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1656095854,
+        "narHash": "sha256-Bksziu35r3/t7qNl6P/LXc/UZDF1zbXCMMvEarPFGUs=",
+        "owner": "hexops-graveyard",
+        "repo": "sdk-macos-12.0",
+        "rev": "14613b4917c7059dad8f3789f55bb13a2548f83d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hexops-graveyard",
+        "repo": "sdk-macos-12.0",
         "type": "github"
       }
     },
@@ -159,6 +175,7 @@
         "crane": "crane",
         "fenix": "fenix",
         "flake-utils": "flake-utils",
+        "macos-sdk": "macos-sdk",
         "nix-filter": "nix-filter",
         "nix-log": [
           "nix-log"
@@ -170,11 +187,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1689772236,
-        "narHash": "sha256-ebhzvmY1o78PU0fH49bTNIOVBcLuoHdWVLUvnhoxXII=",
+        "lastModified": 1693327678,
+        "narHash": "sha256-UQoH8G4uOWXPsgD7v30kbIOBkq15T4yk6XlTZt9of+8=",
         "owner": "rvolosatovs",
         "repo": "nixify",
-        "rev": "388cd4a870bef1501d10f6b72933c658419922eb",
+        "rev": "8c5e4e0183fbd09c811fa5ff8a36cd62ef601a95",
         "type": "github"
       },
       "original": {
@@ -185,11 +202,11 @@
     },
     "nixlib": {
       "locked": {
-        "lastModified": 1689469483,
-        "narHash": "sha256-2SBhY7rZQ/iNCxe04Eqxlz9YK9KgbaTMBssq3/BgdWY=",
+        "lastModified": 1693097231,
+        "narHash": "sha256-EDdqqfZrij2TiBnmtt3+zbzYem9aS4qfKHCJO4mt0Lg=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "02fea408f27186f139153e1ae88f8ab2abd9c22c",
+        "rev": "df6165f357f8ec28ae65789cfed110ebef583dd3",
         "type": "github"
       },
       "original": {
@@ -200,11 +217,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1688221086,
-        "narHash": "sha256-cdW6qUL71cNWhHCpMPOJjlw0wzSRP0pVlRn2vqX/VVg=",
+        "lastModified": 1691371061,
+        "narHash": "sha256-BxPbPVlBIoneaXIBiHd0LVzA+L4nmvFCNBU6TmQAiMM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cd99c2b3c9f160cd004318e0697f90bbd5960825",
+        "rev": "5068bc8fe943bde3c446326da8d0ca9c93d5a682",
         "type": "github"
       },
       "original": {
@@ -216,11 +233,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1689630009,
-        "narHash": "sha256-p+gQ7hm4780wZXDui+PnIWdaXQBKWYWyhr1wET3wW5c=",
+        "lastModified": 1692690972,
+        "narHash": "sha256-Zwv7ihHZX2vNWEwxCI4ENHvsSNlrFs6/TmgZZx7zOyo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5f6211931372b1fb0c4ada2602ffb4d421893c06",
+        "rev": "b7589ceaeea275918c209db1c9a2c51e327af1ee",
         "type": "github"
       },
       "original": {
@@ -240,11 +257,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1689616267,
-        "narHash": "sha256-1F1PWMb6zs0h7JdZTuxDP77f7eXNXzqnabilwm5dByw=",
+        "lastModified": 1692605210,
+        "narHash": "sha256-4Iipx8N7GxQLyPUGTCHPEon7Duko31FCoqDef3kveIU=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "cc2f0ec32cdd86c33e8a5c41dfbc842ad43f5a97",
+        "rev": "9b3d03408c66749d56466bb09baf2a7177deb6ce",
         "type": "github"
       },
       "original": {
@@ -266,11 +283,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1689647697,
-        "narHash": "sha256-8ZX/DVpKLmr85FRKILb+2p+JuxfLQ49LjXG/gmwsoIU=",
+        "lastModified": 1692670201,
+        "narHash": "sha256-WbCKJRfh1Zb7N7g8Fzq7/Hg6i6yCbvaa0OAi4cSHk1w=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "ed2774a9131ddad12e552ba04bd92f87df04a28b",
+        "rev": "bf5196c27545735374376d96d41f209bae3643e1",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -169,9 +169,8 @@
           pkgsCross ? pkgs,
           ...
         } @ args: {
-          buildInputs ? [],
-          depsBuildBuild ? [],
           doCheck,
+          buildInputs ? [],
           preBuild ? "",
           ...
         } @ craneArgs:
@@ -191,15 +190,10 @@
                 });
               });
           in
-            {
-              depsBuildBuild =
-                depsBuildBuild
-                ++ optional stdenv.hostPlatform.isDarwin libiconv;
-            }
-            // optionalAttrs (craneArgs ? cargoArtifacts) {
+            optionalAttrs (craneArgs ? cargoArtifacts) {
               buildInputs =
                 buildInputs
-                ++ optionals stdenv.hostPlatform.isDarwin [
+                ++ optionals (pkgs.stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isDarwin) [
                   pkgs.darwin.apple_sdk.frameworks.Security
                   pkgs.libiconv
                 ];


### PR DESCRIPTION
Since https://github.com/rvolosatovs/nixify/pull/148 is merged, Mac binaries can now be built on Linux (and `aarch64` darwin binaries now should have valid signatures, meaning they do not crash on startup anymore, yay)