### PR TITLE
feat(proxy): Adding support to pull wit deps behind a proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,6 +1834,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2267,6 +2273,7 @@ dependencies = [
  "toml",
  "tracing",
  "url",
+ "urlencoding",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ Note, `wit-deps` assumes that it has full control over `wit/deps` and so it may 
 
 Use `wit-deps` or `wit-deps lock` to populate `wit/deps` using  `wit/deps.toml` manifest and `wit/deps.lock` (will be created if it does not exist)
 
+To you it with a proxy, use the below environment variables:
+```
+export PROXY_SERVER={yourproxyaddress}:{port}
+export PROXY_USERNAME='{yourproxyusername}'
+export PROXY_PASSWORD='{yourproxypassword}'
+```
+
 ## Rust
 
 Use `wit-deps::lock!` macro in `build.rs` of your project to automatically lock your `wit/deps`.

--- a/crates/wit-deps/Cargo.toml
+++ b/crates/wit-deps/Cargo.toml
@@ -27,6 +27,7 @@ tokio-util = { workspace = true, features = ["compat"] }
 toml = { workspace = true, features = ["display", "parse", "preserve_order"] }
 tracing = { workspace = true, features = ["attributes"] }
 url = { workspace = true, features = ["serde"] }
+urlencoding = "2.1"
 
 [features]
 default = ["sync"]

--- a/crates/wit-deps/src/manifest.rs
+++ b/crates/wit-deps/src/manifest.rs
@@ -191,13 +191,18 @@ impl Entry {
         skip_deps: &HashSet<Identifier>,
     ) -> anyhow::Result<(LockEntry, HashMap<Identifier, LockEntry>)> {
         let out = out.as_ref();
-        let proxy_url = env::var("PROXY_SERVER")
-            .ok();
-        let proxy_username = env::var("PROXY_USERNAME")
-            .ok();
+        let proxy_url = env::var("PROXY_SERVER").ok();
+        let proxy_username = env::var("PROXY_USERNAME").ok();
         let proxy_password = env::var("PROXY_PASSWORD").ok();
-        let http_client = if let (Some(proxy_url), Some(proxy_username), Some(proxy_password)) = (proxy_url, proxy_username, proxy_password) {
-            let proxy_with_auth = format!("http://{}:{}@{}", encode(&proxy_username), encode(&proxy_password), proxy_url);
+        let http_client = if let (Some(proxy_url), Some(proxy_username), Some(proxy_password)) =
+            (proxy_url, proxy_username, proxy_password)
+        {
+            let proxy_with_auth = format!(
+                "http://{}:{}@{}",
+                encode(&proxy_username),
+                encode(&proxy_password),
+                proxy_url
+            );
             reqwest::Client::builder()
                 .proxy(Proxy::all(&proxy_with_auth)?)
                 .build()
@@ -331,8 +336,10 @@ impl Entry {
                 let (digest, deps) = match url.scheme() {
                     "http" | "https" => {
                         info!("fetch `{url}` into `{}`", out.display());
-                        
-                        let res = http_client.get(url.clone()).send()
+
+                        let res = http_client
+                            .get(url.clone())
+                            .send()
                             .await
                             .context("failed to GET")
                             .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?

--- a/crates/wit-deps/src/manifest.rs
+++ b/crates/wit-deps/src/manifest.rs
@@ -204,7 +204,7 @@ impl Entry {
                 proxy_url
             );
             reqwest::Client::builder()
-                .proxy(Proxy::all(&proxy_with_auth)?)
+                .proxy(Proxy::all(proxy_with_auth)?)
                 .build()
                 .expect("failed to create client")
         } else {


### PR DESCRIPTION
This PR allows us to run wit deps from behind a proxy . If the proxy env vars are not set, it works as-is.