### PR TITLE
Sanitize dependency names for filesystem compatibility

### DIFF
--- a/crates/wit-deps/src/manifest.rs
+++ b/crates/wit-deps/src/manifest.rs
@@ -245,7 +245,9 @@ impl Entry {
                     .parent()
                     .with_context(|| format!("`{}` does not have a parent", out.display()))?;
                 lock_deps(ldeps.iter().cloned().map(|id| {
-                    let path = base.join(&id);
+                    // Sanitize dependency name for filesystem compatibility
+                    let sanitized_id = id.replace(":", "_");
+                    let path = base.join(&sanitized_id);
                     (id, path)
                 }))
                 .await

--- a/crates/wit-deps/src/manifest.rs
+++ b/crates/wit-deps/src/manifest.rs
@@ -246,7 +246,7 @@ impl Entry {
                     .with_context(|| format!("`{}` does not have a parent", out.display()))?;
                 lock_deps(ldeps.iter().cloned().map(|id| {
                     // Sanitize dependency name for filesystem compatibility
-                    let sanitized_id = id.replace(":", "_");
+                    let sanitized_id = id.replace(":", "-");
                     let path = base.join(&sanitized_id);
                     (id, path)
                 }))

--- a/crates/wit-deps/src/manifest.rs
+++ b/crates/wit-deps/src/manifest.rs
@@ -246,7 +246,7 @@ impl Entry {
                     .with_context(|| format!("`{}` does not have a parent", out.display()))?;
                 lock_deps(ldeps.iter().cloned().map(|id| {
                     // Sanitize dependency name for filesystem compatibility
-                    let sanitized_id = id.replace(':', '-');
+                    let sanitized_id = id.replace(':', "-");
                     let path = base.join(&sanitized_id);
                     (id, path)
                 }))

--- a/crates/wit-deps/src/manifest.rs
+++ b/crates/wit-deps/src/manifest.rs
@@ -245,7 +245,10 @@ impl Entry {
                     .parent()
                     .with_context(|| format!("`{}` does not have a parent", out.display()))?;
                 lock_deps(ldeps.iter().cloned().map(|id| {
-                    // Sanitize dependency name for filesystem compatibility
+                    // Sanitize dependency name for filesystem compatibility.
+                    // WIT identifiers must be kebab-case (words separated by '-') and cannot contain underscores or other punctuation.
+                    // See: https://component-model.bytecodealliance.org/design/wit.html#identifiers
+                    // We use '-' as the separator to match WIT spec and ensure Windows compatibility.
                     let sanitized_id = id.replace(':', "-");
                     let path = base.join(&sanitized_id);
                     (id, path)

--- a/crates/wit-deps/src/manifest.rs
+++ b/crates/wit-deps/src/manifest.rs
@@ -246,7 +246,7 @@ impl Entry {
                     .with_context(|| format!("`{}` does not have a parent", out.display()))?;
                 lock_deps(ldeps.iter().cloned().map(|id| {
                     // Sanitize dependency name for filesystem compatibility
-                    let sanitized_id = id.replace(":", "-");
+                    let sanitized_id = id.replace(':', '-');
                     let path = base.join(&sanitized_id);
                     (id, path)
                 }))


### PR DESCRIPTION
Ensure dependency names are sanitized by replacing colons with underscores to maintain filesystem compatibility.

Fixes #285