### PR TITLE
feat: recursive subdirs

### DIFF
--- a/examples/http/wit/deps.lock
+++ b/examples/http/wit/deps.lock
@@ -1,29 +1,41 @@
 [cli]
-sha256 = "4dadd13d55aaf626833d1f4b9c34a17b0f04e993babd09552b785cda3b95ea76"
-sha512 = "898dcc4e8c15d18acc6b88dbe232336fa4d19019430a910dbc9e7aeaace3077a164af3be9f002de6e7e65ef693df340801ac0c7e421e9a746bf1b6d698a90835"
+url = "https://github.com/WebAssembly/WASI/archive/v0.2.9.tar.gz"
+subdir = "proposals/cli/wit"
+sha256 = "352a505de5c9236597b483a7b407e855ce60b7c68da38ad79f3fdd8dae89f552"
+sha512 = "afd75448f8aa523c514faa919759357ee972b32dca59c828b0654b7978d2ea06ddab00576288e30e76717a3019dbe40a6cc0a19d399f4d292893d9d9acfdd791"
 
 [clocks]
-sha256 = "93a701968a7dd3c5d69031bc0601681c468972fdf7e28a93bb6150a67d6ebe8b"
-sha512 = "98fca567c7a01887b0fb38981f1772169b6ea8de475b546508f8b86738d84e44ba95cae81def40ac34e8809f5f60e85224077ab8cb6d6d5d6296acc1df73c159"
+url = "https://github.com/WebAssembly/WASI/archive/v0.2.9.tar.gz"
+subdir = "proposals/clocks/wit"
+sha256 = "b9fe6015a69eec7ce906a2fe9e6422e09d84e5905f8b2c48c9f9db4932ae6336"
+sha512 = "fc16682461807392565b7f7a3bc01d233e794a8dd82bd5de9263e608c96cc3aa754d0f5d1e9c1573faece8c7ffd3a87b7290bbcdf6d515478c5bcf1b0cb9e5c7"
 
 [filesystem]
-sha256 = "69d42fb10a04a33545b17e055f13db9b1e10e82ba0ed5bdb52334e40dc07c679"
-sha512 = "612effbac6f4804fe0c29dae20b78bbba59e52cb754c15402f5fe229c3153a221e0fbdff1d9d00ceaa3fe049c6a95523a5b99f772f1c16d972eade2c88326a30"
+url = "https://github.com/WebAssembly/WASI/archive/v0.2.9.tar.gz"
+subdir = "proposals/filesystem/wit"
+sha256 = "840d7b3c0a3cac44f90fbc875f9772788220cbfd63881570b504b614087d2f76"
+sha512 = "c9266a095e4a0f6cc4e071d7da54ae88d9c70128681fd66fdf5ee626f35636db8afbabdb73ce2b28959e107c750abbc014aec29423e7363614a180d3c9075776"
 
 [http]
-url = "https://github.com/WebAssembly/wasi-http/archive/v0.2.3.tar.gz"
-sha256 = "72d3a00dbf39eed40a134e8b1dee85834961153f9d205ee4dd56657270c084ce"
-sha512 = "636150c464c0eb3d60bd212fc5d4012638c8cd4f89b583b87a38154ef99de828aac4296ac13c5cface10ee61e164fcfc43a5c104f916229dfdf49c0d11047677"
-deps = ["cli", "clocks", "filesystem", "io", "random", "sockets"]
+url = "https://github.com/WebAssembly/WASI/archive/v0.2.9.tar.gz"
+subdir = "proposals/http/wit"
+sha256 = "1c1b91e1b93fa5f778134ddf84c6e565048792ea4269390de3547aebdc00ef1b"
+sha512 = "acec6e36a3057b4d0a12905681feafc064169a6cf7da0bc50e71ae9c708e1ac1ddc23f787cd7d3ff3406e02ce18209d6c7208e37a581694621ab74a1222a531f"
 
 [io]
-sha256 = "1cccbfe4122686ea57a25cd368e8cdfc408cbcad089f47fb6685b6f92e96f050"
-sha512 = "7a95f964c13da52611141acd89bc8876226497f128e99dd176a4270c5b5efbd8cc847b5fbd1a91258d028c646db99e0424d72590cf1caf20f9f3a3343fad5017"
+url = "https://github.com/WebAssembly/WASI/archive/v0.2.9.tar.gz"
+subdir = "proposals/io/wit"
+sha256 = "3699f94c981bacfd4034e92d47d0c888befb9297c54f6082bd37e83c86e5796e"
+sha512 = "fd3fdd9d6b0df1ee8846aaaba469942e110c6ffc935d331651e338ff9c75b453748d626fffeee9a6026f1ed90d94d8854887e209c5832acc26da6385d189db6b"
 
 [random]
-sha256 = "dd0c91e7125172eb8fd4568e15ad9fc7305643015e6ece4396c3cc5e8c2bf79a"
-sha512 = "d1ca2e7b0616a94a3b39d1b9450bb3fb595b01fd94a8626ad75433038dde40988ecb41ab93a374d569ab72163af3b30038d7bfc3499b9c07193181f4f1d9292a"
+url = "https://github.com/WebAssembly/WASI/archive/v0.2.9.tar.gz"
+subdir = "proposals/random/wit"
+sha256 = "4b4ea94130dba45cc9a86eea05778d9d456cfa8c32a568ef92e8525e2300e233"
+sha512 = "141e730abe6d167bfa675d184ea9601f33e0beb2104ed3312b1f0d7239f7e80d5c5eab3b8b926fc9ac5f959ae479245aa4af56c74babfad3d6208951a5b2650b"
 
 [sockets]
-sha256 = "2bc0f65a8046207ee3330ad7d63f6fafeafd4cc0ea4084f081bd5e4f7b177e74"
-sha512 = "3e5490e41547dffa78d52631825d93da8d60f4af0246cbaf97e1ecb879285953a86d5f1f390b10c32f91dd7eaec6f43e625a26b1c92c32a0c86fde428aedaaab"
+url = "https://github.com/WebAssembly/WASI/archive/v0.2.9.tar.gz"
+subdir = "proposals/sockets/wit"
+sha256 = "996840e548a6fddda8ef47863926a7fa86179be5aa8a81edadb2ea9a2dc526c8"
+sha512 = "0698ec81c26ea76939029fc53104c16bd68a1e1a5144863ce041bee0b5a8a0ed31bfa921118e45d262c1d4e882f8014a8aeacc31825b8c0b7d54d5a1c2c51e97"

--- a/examples/http/wit/deps.toml
+++ b/examples/http/wit/deps.toml
@@ -1,1 +1,12 @@
-http = "https://github.com/WebAssembly/wasi-http/archive/v0.2.3.tar.gz"
+# The wasi-http repo has been archived and merged into the main WASI monorepo.
+# Use the `subdir` feature to point to each proposal's wit directory.
+
+http = { url = "https://github.com/WebAssembly/WASI/archive/v0.2.9.tar.gz", subdir = "proposals/http/wit" }
+
+# http's transitive dependencies from the monorepo
+cli = { url = "https://github.com/WebAssembly/WASI/archive/v0.2.9.tar.gz", subdir = "proposals/cli/wit" }
+clocks = { url = "https://github.com/WebAssembly/WASI/archive/v0.2.9.tar.gz", subdir = "proposals/clocks/wit" }
+filesystem = { url = "https://github.com/WebAssembly/WASI/archive/v0.2.9.tar.gz", subdir = "proposals/filesystem/wit" }
+io = { url = "https://github.com/WebAssembly/WASI/archive/v0.2.9.tar.gz", subdir = "proposals/io/wit" }
+random = { url = "https://github.com/WebAssembly/WASI/archive/v0.2.9.tar.gz", subdir = "proposals/random/wit" }
+sockets = { url = "https://github.com/WebAssembly/WASI/archive/v0.2.9.tar.gz", subdir = "proposals/sockets/wit" }

--- a/examples/http/wit/deps/cli/command.wit
+++ b/examples/http/wit/deps/cli/command.wit
@@ -1,4 +1,4 @@
-package wasi:cli@0.2.3;
+package wasi:cli@0.2.9;
 
 @since(version = 0.2.0)
 world command {

--- a/examples/http/wit/deps/cli/imports.wit
+++ b/examples/http/wit/deps/cli/imports.wit
@@ -1,17 +1,17 @@
-package wasi:cli@0.2.3;
+package wasi:cli@0.2.9;
 
 @since(version = 0.2.0)
 world imports {
   @since(version = 0.2.0)
-  include wasi:clocks/imports@0.2.3;
+  include wasi:clocks/imports@0.2.9;
   @since(version = 0.2.0)
-  include wasi:filesystem/imports@0.2.3;
+  include wasi:filesystem/imports@0.2.9;
   @since(version = 0.2.0)
-  include wasi:sockets/imports@0.2.3;
+  include wasi:sockets/imports@0.2.9;
   @since(version = 0.2.0)
-  include wasi:random/imports@0.2.3;
+  include wasi:random/imports@0.2.9;
   @since(version = 0.2.0)
-  include wasi:io/imports@0.2.3;
+  include wasi:io/imports@0.2.9;
 
   @since(version = 0.2.0)
   import environment;

--- a/examples/http/wit/deps/cli/stdio.wit
+++ b/examples/http/wit/deps/cli/stdio.wit
@@ -1,7 +1,7 @@
 @since(version = 0.2.0)
 interface stdin {
   @since(version = 0.2.0)
-  use wasi:io/streams@0.2.3.{input-stream};
+  use wasi:io/streams@0.2.9.{input-stream};
 
   @since(version = 0.2.0)
   get-stdin: func() -> input-stream;
@@ -10,7 +10,7 @@ interface stdin {
 @since(version = 0.2.0)
 interface stdout {
   @since(version = 0.2.0)
-  use wasi:io/streams@0.2.3.{output-stream};
+  use wasi:io/streams@0.2.9.{output-stream};
 
   @since(version = 0.2.0)
   get-stdout: func() -> output-stream;
@@ -19,7 +19,7 @@ interface stdout {
 @since(version = 0.2.0)
 interface stderr {
   @since(version = 0.2.0)
-  use wasi:io/streams@0.2.3.{output-stream};
+  use wasi:io/streams@0.2.9.{output-stream};
 
   @since(version = 0.2.0)
   get-stderr: func() -> output-stream;

--- a/examples/http/wit/deps/clocks/monotonic-clock.wit
+++ b/examples/http/wit/deps/clocks/monotonic-clock.wit
@@ -1,4 +1,4 @@
-package wasi:clocks@0.2.3;
+package wasi:clocks@0.2.9;
 /// WASI Monotonic Clock is a clock API intended to let users measure elapsed
 /// time.
 ///
@@ -10,7 +10,7 @@ package wasi:clocks@0.2.3;
 @since(version = 0.2.0)
 interface monotonic-clock {
     @since(version = 0.2.0)
-    use wasi:io/poll@0.2.3.{pollable};
+    use wasi:io/poll@0.2.9.{pollable};
 
     /// An instant in time, in nanoseconds. An instant is relative to an
     /// unspecified initial value, and can only be compared to instances from
@@ -26,6 +26,11 @@ interface monotonic-clock {
     ///
     /// The clock is monotonic, therefore calling this function repeatedly will
     /// produce a sequence of non-decreasing values.
+    ///
+    /// For completeness, this function traps if it's not possible to represent
+    /// the value of the clock in an `instant`. Consequently, implementations
+    /// should ensure that the starting time is low enough to avoid the
+    /// possibility of overflow in practice.
     @since(version = 0.2.0)
     now: func() -> instant;
 

--- a/examples/http/wit/deps/clocks/timezone.wit
+++ b/examples/http/wit/deps/clocks/timezone.wit
@@ -1,4 +1,4 @@
-package wasi:clocks@0.2.3;
+package wasi:clocks@0.2.9;
 
 @unstable(feature = clocks-timezone)
 interface timezone {

--- a/examples/http/wit/deps/clocks/wall-clock.wit
+++ b/examples/http/wit/deps/clocks/wall-clock.wit
@@ -1,4 +1,4 @@
-package wasi:clocks@0.2.3;
+package wasi:clocks@0.2.9;
 /// WASI Wall Clock is a clock API intended to let users query the current
 /// time. The name "wall" makes an analogy to a "clock on the wall", which
 /// is not necessarily monotonic as it may be reset.

--- a/examples/http/wit/deps/clocks/world.wit
+++ b/examples/http/wit/deps/clocks/world.wit
@@ -1,4 +1,4 @@
-package wasi:clocks@0.2.3;
+package wasi:clocks@0.2.9;
 
 @since(version = 0.2.0)
 world imports {

--- a/examples/http/wit/deps/filesystem/preopens.wit
+++ b/examples/http/wit/deps/filesystem/preopens.wit
@@ -1,4 +1,4 @@
-package wasi:filesystem@0.2.3;
+package wasi:filesystem@0.2.9;
 
 @since(version = 0.2.0)
 interface preopens {

--- a/examples/http/wit/deps/filesystem/types.wit
+++ b/examples/http/wit/deps/filesystem/types.wit
@@ -1,4 +1,4 @@
-package wasi:filesystem@0.2.3;
+package wasi:filesystem@0.2.9;
 /// WASI filesystem is a filesystem API primarily intended to let users run WASI
 /// programs that access their files on their existing filesystems, without
 /// significant overhead.
@@ -26,9 +26,9 @@ package wasi:filesystem@0.2.3;
 @since(version = 0.2.0)
 interface types {
     @since(version = 0.2.0)
-    use wasi:io/streams@0.2.3.{input-stream, output-stream, error};
+    use wasi:io/streams@0.2.9.{input-stream, output-stream, error};
     @since(version = 0.2.0)
-    use wasi:clocks/wall-clock@0.2.3.{datetime};
+    use wasi:clocks/wall-clock@0.2.9.{datetime};
 
     /// File size or length of a region within a file.
     @since(version = 0.2.0)
@@ -507,6 +507,10 @@ interface types {
         ) -> result<_, error-code>;
 
         /// Create a hard link.
+        ///
+        /// Fails with `error-code::no-entry` if the old path does not exist,
+        /// with `error-code::exist` if the new path already exists, and
+        /// `error-code::not-permitted` if the old path is not a file.
         ///
         /// Note: This is similar to `linkat` in POSIX.
         @since(version = 0.2.0)

--- a/examples/http/wit/deps/filesystem/world.wit
+++ b/examples/http/wit/deps/filesystem/world.wit
@@ -1,4 +1,4 @@
-package wasi:filesystem@0.2.3;
+package wasi:filesystem@0.2.9;
 
 @since(version = 0.2.0)
 world imports {

--- a/examples/http/wit/deps/http/proxy.wit
+++ b/examples/http/wit/deps/http/proxy.wit
@@ -1,4 +1,4 @@
-package wasi:http@0.2.3;
+package wasi:http@0.2.9;
 
 /// The `wasi:http/imports` world imports all the APIs for HTTP proxies.
 /// It is intended to be `include`d in other worlds.
@@ -6,25 +6,25 @@ package wasi:http@0.2.3;
 world imports {
   /// HTTP proxies have access to time and randomness.
   @since(version = 0.2.0)
-  import wasi:clocks/monotonic-clock@0.2.3;
+  import wasi:clocks/monotonic-clock@0.2.9;
   @since(version = 0.2.0)
-  import wasi:clocks/wall-clock@0.2.3;
+  import wasi:clocks/wall-clock@0.2.9;
   @since(version = 0.2.0)
-  import wasi:random/random@0.2.3;
+  import wasi:random/random@0.2.9;
 
   /// Proxies have standard output and error streams which are expected to
   /// terminate in a developer-facing console provided by the host.
   @since(version = 0.2.0)
-  import wasi:cli/stdout@0.2.3;
+  import wasi:cli/stdout@0.2.9;
   @since(version = 0.2.0)
-  import wasi:cli/stderr@0.2.3;
+  import wasi:cli/stderr@0.2.9;
 
   /// TODO: this is a temporary workaround until component tooling is able to
   /// gracefully handle the absence of stdin. Hosts must return an eof stream
   /// for this import, which is what wasi-libc + tooling will do automatically
   /// when this import is properly removed.
   @since(version = 0.2.0)
-  import wasi:cli/stdin@0.2.3;
+  import wasi:cli/stdin@0.2.9;
 
   /// This is the default handler to use when user code simply wants to make an
   /// HTTP request (e.g., via `fetch()`).

--- a/examples/http/wit/deps/http/types.wit
+++ b/examples/http/wit/deps/http/types.wit
@@ -4,13 +4,13 @@
 @since(version = 0.2.0)
 interface types {
   @since(version = 0.2.0)
-  use wasi:clocks/monotonic-clock@0.2.3.{duration};
+  use wasi:clocks/monotonic-clock@0.2.9.{duration};
   @since(version = 0.2.0)
-  use wasi:io/streams@0.2.3.{input-stream, output-stream};
+  use wasi:io/streams@0.2.9.{input-stream, output-stream};
   @since(version = 0.2.0)
-  use wasi:io/error@0.2.3.{error as io-error};
+  use wasi:io/error@0.2.9.{error as io-error};
   @since(version = 0.2.0)
-  use wasi:io/poll@0.2.3.{pollable};
+  use wasi:io/poll@0.2.9.{pollable};
 
   /// This type corresponds to HTTP standard Methods.
   @since(version = 0.2.0)
@@ -110,8 +110,8 @@ interface types {
   /// provided.
   ///
   /// Stream operations which return
-  /// `wasi:io/stream/stream-error::last-operation-failed` have a payload of
-  /// type `wasi:io/error/error` with more information about the operation
+  /// `wasi:io/stream.stream-error.last-operation-failed` have a payload of
+  /// type `wasi:io/error.error` with more information about the operation
   /// that failed. This payload can be passed through to this function to see
   /// if there's http-related information about the error to return.
   ///
@@ -170,7 +170,7 @@ interface types {
   /// A `fields` may be mutable or immutable. A `fields` created using the
   /// constructor, `from-list`, or `clone` will be mutable, but a `fields`
   /// resource given by other means (including, but not limited to,
-  /// `incoming-request.headers`, `outgoing-request.headers`) might be be
+  /// `incoming-request.headers`, `outgoing-request.headers`) might be
   /// immutable. In an immutable fields, the `set`, `append`, and `delete`
   /// operations will fail with `header-error.immutable`.
   @since(version = 0.2.0)
@@ -435,6 +435,21 @@ interface types {
   /// other argument to `incoming-handler.handle`.
   @since(version = 0.2.0)
   resource response-outparam {
+    /// Send an HTTP 1xx response.
+    ///
+    /// Unlike `response-outparam.set`, this does not consume the
+    /// `response-outparam`, allowing the guest to send an arbitrary number of
+    /// informational responses before sending the final response using
+    /// `response-outparam.set`.
+    ///
+    /// This will return an `HTTP-protocol-error` if `status` is not in the
+    /// range [100-199], or an `internal-error` if the implementation does not
+    /// support informational responses.
+    @unstable(feature = informational-outbound-responses)
+    send-informational: func(
+      status: u16,
+      headers: headers
+    ) -> result<_, error-code>;
 
     /// Set the value of the `response-outparam` to either send a response,
     /// or indicate an error.

--- a/examples/http/wit/deps/io/error.wit
+++ b/examples/http/wit/deps/io/error.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.3;
+package wasi:io@0.2.9;
 
 @since(version = 0.2.0)
 interface error {
@@ -8,14 +8,14 @@ interface error {
     /// which provides some human-readable information about the error.
     ///
     /// In the `wasi:io` package, this resource is returned through the
-    /// `wasi:io/streams/stream-error` type.
+    /// `wasi:io/streams.stream-error` type.
     ///
     /// To provide more specific error information, other interfaces may
     /// offer functions to "downcast" this error into more specific types. For example,
     /// errors returned from streams derived from filesystem types can be described using
     /// the filesystem's own error-code type. This is done using the function
-    /// `wasi:filesystem/types/filesystem-error-code`, which takes a `borrow<error>`
-    /// parameter and returns an `option<wasi:filesystem/types/error-code>`.
+    /// `wasi:filesystem/types.filesystem-error-code`, which takes a `borrow<error>`
+    /// parameter and returns an `option<wasi:filesystem/types.error-code>`.
     ///
     /// The set of functions which can "downcast" an `error` into a more
     /// concrete type is open.

--- a/examples/http/wit/deps/io/poll.wit
+++ b/examples/http/wit/deps/io/poll.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.3;
+package wasi:io@0.2.9;
 
 /// A poll API intended to let users wait for I/O events on multiple handles
 /// at once.
@@ -8,19 +8,19 @@ interface poll {
     @since(version = 0.2.0)
     resource pollable {
 
-      /// Return the readiness of a pollable. This function never blocks.
-      ///
-      /// Returns `true` when the pollable is ready, and `false` otherwise.
-      @since(version = 0.2.0)
-      ready: func() -> bool;
+        /// Return the readiness of a pollable. This function never blocks.
+        ///
+        /// Returns `true` when the pollable is ready, and `false` otherwise.
+        @since(version = 0.2.0)
+        ready: func() -> bool;
 
-      /// `block` returns immediately if the pollable is ready, and otherwise
-      /// blocks until ready.
-      ///
-      /// This function is equivalent to calling `poll.poll` on a list
-      /// containing only this pollable.
-      @since(version = 0.2.0)
-      block: func();
+        /// `block` returns immediately if the pollable is ready, and otherwise
+        /// blocks until ready.
+        ///
+        /// This function is equivalent to calling `poll.poll` on a list
+        /// containing only this pollable.
+        @since(version = 0.2.0)
+        block: func();
     }
 
     /// Poll for completion on a set of pollables.

--- a/examples/http/wit/deps/io/streams.wit
+++ b/examples/http/wit/deps/io/streams.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.3;
+package wasi:io@0.2.9;
 
 /// WASI I/O is an I/O abstraction API which is currently focused on providing
 /// stream types.
@@ -154,27 +154,13 @@ interface streams {
         /// Perform a write of up to 4096 bytes, and then flush the stream. Block
         /// until all of these operations are complete, or an error occurs.
         ///
-        /// This is a convenience wrapper around the use of `check-write`,
-        /// `subscribe`, `write`, and `flush`, and is implemented with the
-        /// following pseudo-code:
-        ///
-        /// ```text
-        /// let pollable = this.subscribe();
-        /// while !contents.is_empty() {
-        ///     // Wait for the stream to become writable
-        ///     pollable.block();
-        ///     let Ok(n) = this.check-write(); // eliding error handling
-        ///     let len = min(n, contents.len());
-        ///     let (chunk, rest) = contents.split_at(len);
-        ///     this.write(chunk  );            // eliding error handling
-        ///     contents = rest;
-        /// }
-        /// this.flush();
-        /// // Wait for completion of `flush`
-        /// pollable.block();
-        /// // Check for any errors that arose during `flush`
-        /// let _ = this.check-write();         // eliding error handling
-        /// ```
+        /// Returns success when all of the contents written are successfully
+        /// flushed to output. If an error occurs at any point before all
+        /// contents are successfully flushed, that error is returned as soon as
+        /// possible. If writing and flushing the complete contents causes the
+        /// stream to become closed, this call should return success, and
+        /// subsequent calls to check-write or other interfaces should return
+        /// stream-error::closed.
         @since(version = 0.2.0)
         blocking-write-and-flush: func(
             contents: list<u8>
@@ -227,26 +213,8 @@ interface streams {
         /// Block until all of these operations are complete, or an error
         /// occurs.
         ///
-        /// This is a convenience wrapper around the use of `check-write`,
-        /// `subscribe`, `write-zeroes`, and `flush`, and is implemented with
-        /// the following pseudo-code:
-        ///
-        /// ```text
-        /// let pollable = this.subscribe();
-        /// while num_zeroes != 0 {
-        ///     // Wait for the stream to become writable
-        ///     pollable.block();
-        ///     let Ok(n) = this.check-write(); // eliding error handling
-        ///     let len = min(n, num_zeroes);
-        ///     this.write-zeroes(len);         // eliding error handling
-        ///     num_zeroes -= len;
-        /// }
-        /// this.flush();
-        /// // Wait for completion of `flush`
-        /// pollable.block();
-        /// // Check for any errors that arose during `flush`
-        /// let _ = this.check-write();         // eliding error handling
-        /// ```
+        /// Functionality is equivelant to `blocking-write-and-flush` with
+        /// contents given as a list of len containing only zeroes.
         @since(version = 0.2.0)
         blocking-write-zeroes-and-flush: func(
             /// The number of zero-bytes to write

--- a/examples/http/wit/deps/io/world.wit
+++ b/examples/http/wit/deps/io/world.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.3;
+package wasi:io@0.2.9;
 
 @since(version = 0.2.0)
 world imports {

--- a/examples/http/wit/deps/random/insecure-seed.wit
+++ b/examples/http/wit/deps/random/insecure-seed.wit
@@ -1,4 +1,4 @@
-package wasi:random@0.2.3;
+package wasi:random@0.2.9;
 /// The insecure-seed interface for seeding hash-map DoS resistance.
 ///
 /// It is intended to be portable at least between Unix-family platforms and

--- a/examples/http/wit/deps/random/insecure.wit
+++ b/examples/http/wit/deps/random/insecure.wit
@@ -1,4 +1,4 @@
-package wasi:random@0.2.3;
+package wasi:random@0.2.9;
 /// The insecure interface for insecure pseudo-random numbers.
 ///
 /// It is intended to be portable at least between Unix-family platforms and

--- a/examples/http/wit/deps/random/random.wit
+++ b/examples/http/wit/deps/random/random.wit
@@ -1,4 +1,4 @@
-package wasi:random@0.2.3;
+package wasi:random@0.2.9;
 /// WASI Random is a random data API.
 ///
 /// It is intended to be portable at least between Unix-family platforms and

--- a/examples/http/wit/deps/random/world.wit
+++ b/examples/http/wit/deps/random/world.wit
@@ -1,4 +1,4 @@
-package wasi:random@0.2.3;
+package wasi:random@0.2.9;
 
 @since(version = 0.2.0)
 world imports {

--- a/examples/http/wit/deps/sockets/ip-name-lookup.wit
+++ b/examples/http/wit/deps/sockets/ip-name-lookup.wit
@@ -1,7 +1,7 @@
 @since(version = 0.2.0)
 interface ip-name-lookup {
     @since(version = 0.2.0)
-    use wasi:io/poll@0.2.3.{pollable};
+    use wasi:io/poll@0.2.9.{pollable};
     @since(version = 0.2.0)
     use network.{network, error-code, ip-address};
 

--- a/examples/http/wit/deps/sockets/network.wit
+++ b/examples/http/wit/deps/sockets/network.wit
@@ -1,7 +1,7 @@
 @since(version = 0.2.0)
 interface network {
     @unstable(feature = network-error-code)
-    use wasi:io/error@0.2.3.{error};
+    use wasi:io/error@0.2.9.{error};
 
     /// An opaque resource that represents access to (a subset of) the network.
     /// This enables context-based security for networking.

--- a/examples/http/wit/deps/sockets/tcp.wit
+++ b/examples/http/wit/deps/sockets/tcp.wit
@@ -1,11 +1,11 @@
 @since(version = 0.2.0)
 interface tcp {
     @since(version = 0.2.0)
-    use wasi:io/streams@0.2.3.{input-stream, output-stream};
+    use wasi:io/streams@0.2.9.{input-stream, output-stream};
     @since(version = 0.2.0)
-    use wasi:io/poll@0.2.3.{pollable};
+    use wasi:io/poll@0.2.9.{pollable};
     @since(version = 0.2.0)
-    use wasi:clocks/monotonic-clock@0.2.3.{duration};
+    use wasi:clocks/monotonic-clock@0.2.9.{duration};
     @since(version = 0.2.0)
     use network.{network, error-code, ip-socket-address, ip-address-family};
 

--- a/examples/http/wit/deps/sockets/udp.wit
+++ b/examples/http/wit/deps/sockets/udp.wit
@@ -1,7 +1,7 @@
 @since(version = 0.2.0)
 interface udp {
     @since(version = 0.2.0)
-    use wasi:io/poll@0.2.3.{pollable};
+    use wasi:io/poll@0.2.9.{pollable};
     @since(version = 0.2.0)
     use network.{network, error-code, ip-socket-address, ip-address-family};
 

--- a/examples/http/wit/deps/sockets/world.wit
+++ b/examples/http/wit/deps/sockets/world.wit
@@ -1,4 +1,4 @@
-package wasi:sockets@0.2.3;
+package wasi:sockets@0.2.9;
 
 @since(version = 0.2.0)
 world imports {

--- a/examples/http/wit/world.wit
+++ b/examples/http/wit/world.wit
@@ -1,5 +1,5 @@
 package examples:http;
 
 world http {
-    import wasi:http/incoming-handler@0.2.3;
+    import wasi:http/incoming-handler@0.2.9;
 }


### PR DESCRIPTION
Add support for nested subdirs.

The untar function was rewritten to handle multi-component subdir paths like `proposals/http/wit`.

Updated the example to use WASI monorepo by changing from archived wasi-http repo to the main WebAssembly/WASI monorepo with nested subdir paths for each proposal. Note I had to bump the version here (sorry for the extra diff), but necessary as the file structure with proposals/* doesn't exist on the v0.2.3 tag.
