### PR TITLE
feat(cargo,packaging): add `cargo-binstall` metadata to wit-deps-cli

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,14 @@ license.workspace = true
 repository.workspace = true
 
 [package.metadata.binstall]
-pkg-url = "{repo}/releases/download/v{version}/wit-deps-{target-arch}-{target-vendor}-{target-family}-musl"
+pkg-url = "{repo}/releases/download/v{version}/wit-deps-{target}"
 pkg-fmt = "bin"
-[package.metadata.binstall.overrides.aarch64-apple-darwin]
-pkg-url = "{repo}/releases/download/v{version}/wit-deps-{target-arch}-{target-vendor}-{target-family}"
-[package.metadata.binstall.overrides.x86_64-apple-darwin]
-pkg-url = "{repo}/releases/download/v{version}/wit-deps-{target-arch}-{target-vendor}-{target-family}"
+[package.metadata.binstall.overrides.aarch64-unknown-linux-gnu]
+pkg-url = "{repo}/releases/download/v{version}/wit-deps-{target-arch}-{target-vendor}-{target-family}-musl"
+[package.metadata.binstall.overrides.x86_64-unknown-linux-gnu]
+pkg-url = "{repo}/releases/download/v{version}/wit-deps-{target-arch}-{target-vendor}-{target-family}-musl"
+[package.metadata.binstall.overrides.armv7-unknown-linux-gnu]
+pkg-url = "{repo}/releases/download/v{version}/wit-deps-{target-arch}-{target-vendor}-{target-family}-musleabihf"
 [package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
 # GNU toolchain should work on windows MSVC targets
 pkg-url = "{repo}/releases/download/v{version}/wit-deps-{target-arch}-{target-vendor}-{target-family}-gnu"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ sockets = "https://github.com/WebAssembly/wasi-sockets/archive/main.tar.gz"
 sql = "https://github.com/WebAssembly/wasi-sql/archive/main.tar.gz"
 
 # Pin to a tag
-io = "https://github.com/rvolosatovs/wasi-io/archive/v0.1.0.tar.gz" # this fork renames `streams` interface for compatiblity with wasi-snapshot-preview1
+io = "https://github.com/rvolosatovs/wasi-io/archive/v0.1.0.tar.gz" # this fork renames `streams` interface for compatibility with wasi-snapshot-preview1
 
 # Pin a dependency to a particular revision and source digests. Each digest is optional
 [keyvalue]
@@ -28,7 +28,7 @@ sha512 = "7bc43665a9de73ec7bef075e32f67ed0ebab04a1e47879f9328e8e52edfb35359512c8
 
 ```
 
-A source specfication can also be a structure with the following fields:
+A source specification can also be a structure with the following fields:
 
 - `url` - same format as the URL string
 - `sha256` - (optional) hex-encoded sha256 digest of the contents of the URL


### PR DESCRIPTION
Using [wasmtime manifest](https://github.com/bytecodealliance/wasmtime/blob/3e3fafe8c61d2506c50a8dc2b179a4c3feb08695/Cargo.toml#L16-L32) as reference, added `cargo-binstall` ability to download from the github releases:

https://github.com/bytecodealliance/wit-deps/blob/074a6fafc9510623d9e45a2d91aed42d98452a85/Cargo.toml#L12-L21

`cargo-binstall` reference doc for URLs: https://github.com/cargo-bins/cargo-binstall/blob/main/SUPPORT.md#support-for-cargo-binstall