### PR TITLE
Document installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
 
 `wit-deps` is a simple WIT dependency manager binary and Rust library, which manages your `wit/deps`. It's main objective is to ensure that whatever is located in your `wit/deps` is consistent with your dependency manifest (default: `wit/deps.toml`) and dependency lock (default: `wit/deps.lock`).
 
+# Installation
+
+Install the command-line tool with Cargo:
+
+```sh
+cargo install wit-deps-cli
+```
+
+After installation, run:
+
+```sh
+wit-deps --help
+```
+
 # Manifest
 
 A dependency manifest is a TOML-encoded table mapping dependency names to their source specifications. In it's simplest form, a source specification is a URL string of a gzipped tarball containing a directory tree with a `wit` subdirectory containing `wit` files.


### PR DESCRIPTION
This PR adds a short Installation section to the README.

It documents how to install the command-line tool with Cargo using `cargo install wit-deps-cli`, and adds a quick `wit-deps --help` command so users can verify the installation.

Closes #158.